### PR TITLE
#57 Add onnx export after compression

### DIFF
--- a/netspresso/compressor/__init__.py
+++ b/netspresso/compressor/__init__.py
@@ -30,6 +30,7 @@ from netspresso.compressor.client.schemas.compression import (
 from netspresso.compressor.core.model import CompressedModel, Model, ModelCollection, ModelFactory
 from netspresso.compressor.core.compression import CompressionInfo
 from netspresso.client import BaseClient, validate_token
+from .utils.onnx import export_onnx
 
 
 class ModelCompressor(BaseClient):
@@ -413,6 +414,8 @@ class ModelCompressor(BaseClient):
             self.client.compress_model(data=data, access_token=self.user_session.access_token)
             self.download_model(model_id=compression_info.new_model_id, local_path=output_path)
             compressed_model = self.get_model(model_id=compression_info.new_model_id)
+            if compressed_model.framework in [Framework.PYTORCH, Framework.ONNX]:
+                export_onnx(output_path, compressed_model.input_shapes)
             logger.info(f"Compress model successfully. Compressed Model ID: {compressed_model.model_id}")
             logger.info("50 credits have been consumed.")
 
@@ -516,6 +519,8 @@ class ModelCompressor(BaseClient):
             self.client.compress_model(data=data, access_token=self.user_session.access_token)
             self.download_model(model_id=compression_info.new_model_id, local_path=output_path)
             compressed_model = self.get_model(model_id=compression_info.new_model_id)
+            if compressed_model.framework in [Framework.PYTORCH, Framework.ONNX]:
+                export_onnx(output_path, compressed_model.input_shapes)
             logger.info(f"Recommendation compression successfully. Compressed Model ID: {compressed_model.model_id}")
             logger.info("50 credits have been consumed.")
 
@@ -555,6 +560,8 @@ class ModelCompressor(BaseClient):
             model_info = self.client.auto_compression(data=data, access_token=self.user_session.access_token)
             self.download_model(model_id=model_info.model_id, local_path=output_path)
             compressed_model = self.model_factory.create_compressed_model(model_info=model_info)
+            if compressed_model.framework in [Framework.PYTORCH, Framework.ONNX]:
+                export_onnx(output_path, compressed_model.input_shapes)
             logger.info(f"Automatic compression successfully. Compressed Model ID: {compressed_model.model_id}")
             logger.info("25 credits have been consumed.")
 

--- a/netspresso/compressor/__init__.py
+++ b/netspresso/compressor/__init__.py
@@ -228,7 +228,7 @@ class ModelCompressor(BaseClient):
                 logger.info(f"The specified folder does not exist. Local Path: {Path(local_path).parent}")
                 Path(local_path).parent.mkdir(parents=True, exist_ok=True)
             request.urlretrieve(download_link.url, local_path)
-            logger.info(f"Model downloaded at {local_path}")
+            logger.info(f"Model downloaded at {Path(local_path)}")
 
         except Exception as e:
             logger.error(f"Download model failed. Error: {e}")

--- a/netspresso/compressor/utils/onnx.py
+++ b/netspresso/compressor/utils/onnx.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+from typing import Union, List
+
+import torch
+import torch.nn as nn
+from torch import Tensor
+from loguru import logger
+
+
+def _export_onnx(
+    model: nn.Module,
+    save_path: Union[str, Path],
+    sample_input: Tensor,
+    opset_version=13,
+    input_names="images",
+    output_names="output",
+):
+    torch.onnx.export(
+        model,  # model being run
+        sample_input,  # model input (or a tuple for multiple inputs)
+        save_path,  # where to save the model (can be a file or file-like object)
+        export_params=True,  # store the trained parameter weights inside the model file
+        opset_version=opset_version,  # the ONNX version to export the model to
+        do_constant_folding=True,  # whether to execute constant folding for optimization
+        input_names=[input_names],  # the model's input names
+        output_names=[output_names],  # the model's output names
+        dynamic_axes={input_names: {0: "batch_size"}, output_names: {0: "batch_size"}},  # variable length axes
+    )
+    logger.info(f"ONNX model converting and saved at {save_path}")
+
+
+def export_onnx(file_path: str, input_shapes: List[int]):
+    file_path = Path(file_path)
+    model = torch.load(file_path)
+
+    input_shape = input_shapes[0]
+    sample_input = torch.randn((1, input_shape.channel, *input_shape.dimension))
+    save_dtype = next(model.parameters()).dtype
+
+    return _export_onnx(model, file_path.with_suffix(".onnx"), sample_input=sample_input.type(save_dtype))

--- a/netspresso/launcher/__init__.py
+++ b/netspresso/launcher/__init__.py
@@ -214,7 +214,7 @@ class ModelConverter(Launcher):
             logger.info(f"The specified folder does not exist. Local Path: {Path(local_path).parent}")
             Path(local_path).parent.mkdir(parents=True, exist_ok=True)
         request.urlretrieve(download_url, local_path)
-        logger.info(f"Model downloaded at {local_path}")
+        logger.info(f"Model downloaded at {Path(local_path)}")
 
 
 class ModelBenchmarker(Launcher):

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ requests==2.30.0
 email-validator==2.0.0
 pytz==2023.3
 typing_extensions==4.5.0
+torch>=1.13.0
+torchvision>=0.14.0


### PR DESCRIPTION
## Description

Please include a summary in English, of the changes in this pull request. If it closes an issue, please mention it here.

- Add exporting to ONNX for immediate use with the converter and benchmark after compression

Closes: #57 

You should link at least one existing issue for PR. Before your create a PR, please check to see if there is an issue for this change.  
PRs from forked repository not accepted.

## Change(s)

- Add export_onnx function
- Add torch(>=1.13) & torchvision(>=1.14) in requirements.txt
