### PR TITLE
#199 Change default value of step_size from 8 to 2

### DIFF
--- a/examples/compressor/manual_compression.py
+++ b/examples/compressor/manual_compression.py
@@ -24,7 +24,7 @@ OPTIONS = Options(
     layer_norm=LayerNorm.STANDARD_SCORE,
     group_policy=GroupPolicy.AVERAGE,
     reshape_channel_axis=-1,
-    step_size=8,
+    step_size=2,
     step_op=StepOp.ROUND,
 )
 compression_info = compressor.select_compression_method(

--- a/netspresso/clients/compressor/schemas/compression.py
+++ b/netspresso/clients/compressor/schemas/compression.py
@@ -32,7 +32,7 @@ class Options(OptionsBase):
     policy: policy_literal = Field(Policy.AVERAGE, description="Policy")
     layer_norm: layernorm_literal = Field(LayerNorm.STANDARD_SCORE, description="layer Norm")
     group_policy: grouppolicy_literal = Field(GroupPolicy.AVERAGE, description="Group Policy")
-    step_size: int = Field(8, description="Step Size")
+    step_size: int = Field(2, description="Step Size")
     step_op: stepop_literal = Field(StepOp.ROUND, description="Step Operator")
     reverse: bool = Field(False, description="Reverse")
 

--- a/netspresso/compressor/core/compression.py
+++ b/netspresso/compressor/core/compression.py
@@ -36,7 +36,7 @@ class Options:
     policy: Policy = Policy.AVERAGE
     layer_norm: LayerNorm = LayerNorm.STANDARD_SCORE
     group_policy: GroupPolicy = GroupPolicy.AVERAGE
-    step_size: int = 8
+    step_size: int = 2
     step_op: StepOp = StepOp.ROUND
     reverse: bool = False
 


### PR DESCRIPTION
## Description

Please include a summary in English, of the changes in this pull request. If it closes an issue, please mention it here.

Closes: #199 

You should link at least one existing issue for PR. Before your create a PR, please check to see if there is an issue for this change.  
PRs from forked repository not accepted.

## Change(s)

- Change default value of step_size from 8 to 2.
- Default value of each pruning option.
  - step_size: `2`
  - step_op: `StepOp.ROUND`

- Ex)
```
from netspresso.enums import Options, StepOp

OPTIONS = Options(step_size=2, step_op=StepOp.ROUND)
```
