### PR TITLE
#245 Set download_model path extension to .pt

### DIFF
--- a/netspresso/compressor/compressor.py
+++ b/netspresso/compressor/compressor.py
@@ -422,7 +422,7 @@ class Compressor:
 
             self.download_model(
                 model_id=compression_info.new_model_id,
-                local_path=default_model_path.with_suffix('.pt'),
+                local_path=default_model_path.with_suffix(extension),
             )
             compressed_model = self.get_model(model_id=compression_info.new_model_id)
 
@@ -605,7 +605,7 @@ class Compressor:
 
             self.download_model(
                 model_id=compression_info.new_model_id,
-                local_path=default_model_path.with_suffix('.pt'),
+                local_path=default_model_path.with_suffix(extension),
             )
             compressed_model = self.get_model(model_id=compression_info.new_model_id)
 
@@ -719,7 +719,7 @@ class Compressor:
 
             self.download_model(
                 model_id=model_info.model_id,
-                local_path=default_model_path.with_suffix('.pt'),
+                local_path=default_model_path.with_suffix(extension),
             )
             compressed_model = self.model_factory.create_compressed_model(model_info=model_info)  # TODO: delete
 

--- a/netspresso/compressor/compressor.py
+++ b/netspresso/compressor/compressor.py
@@ -422,7 +422,7 @@ class Compressor:
 
             self.download_model(
                 model_id=compression_info.new_model_id,
-                local_path=default_model_path.with_suffix(extension),
+                local_path=default_model_path.with_suffix('.pt'),
             )
             compressed_model = self.get_model(model_id=compression_info.new_model_id)
 
@@ -605,7 +605,7 @@ class Compressor:
 
             self.download_model(
                 model_id=compression_info.new_model_id,
-                local_path=default_model_path.with_suffix(extension),
+                local_path=default_model_path.with_suffix('.pt'),
             )
             compressed_model = self.get_model(model_id=compression_info.new_model_id)
 
@@ -719,7 +719,7 @@ class Compressor:
 
             self.download_model(
                 model_id=model_info.model_id,
-                local_path=default_model_path.with_suffix(extension),
+                local_path=default_model_path.with_suffix('.pt'),
             )
             compressed_model = self.model_factory.create_compressed_model(model_info=model_info)  # TODO: delete
 

--- a/netspresso/utils/file.py
+++ b/netspresso/utils/file.py
@@ -8,7 +8,7 @@ from urllib import request
 FRAMEWORK_EXTENSION_MAP = {
     "tensorflow_keras": ".h5",
     "pytorch": ".pt",
-    "onnx": ".onnx",
+    "onnx": ".pt",
     "tensorflow_lite": ".tflite",
     "drpai": ".zip",
     "openvino": ".zip",


### PR DESCRIPTION
## Description

Please include a summary in English, of the changes in this pull request. If it closes an issue, please mention it here.

Closes: #245

You should link at least one existing issue for PR. Before your create a PR, please check to see if there is an issue for this change.  
PRs from forked repository not accepted.

## Change(s)

- Set `download_model` path extension to `.pt`
- They are in `compress_model`, `recommendation_compression` and `recommendation_compression` methods.
