### PR TITLE
#343 Exclude `dlc` framework from available options

### DIFF
--- a/netspresso/compressor/v2/compressor.py
+++ b/netspresso/compressor/v2/compressor.py
@@ -98,6 +98,13 @@ class CompressorV2(NetsPressoBase):
 
         available_options = options_response.data
 
+        # TODO: Will be removed when we support DLC in the future
+        available_options = [
+            available_option
+            for available_option in available_options
+            if available_option.framework != "dlc"
+        ]
+
         return available_options
 
     def _postprocess_metadata(


### PR DESCRIPTION
## Description

Please include a summary in English, of the changes in this pull request. If it closes an issue, please mention it here.

Closes: #343 

You should link at least one existing issue for PR. Before your create a PR, please check to see if there is an issue for this change.  
PRs from forked repository not accepted.

## Change(s)

- Exclude `dlc` framework from available options.
  - We plan to remove that logic when we support DLC in the future.
