### PR TITLE
#345 Exclude `dlc` framework from available options in trainer metadata

### DIFF
--- a/netspresso/trainer/trainer.py
+++ b/netspresso/trainer/trainer.py
@@ -465,6 +465,13 @@ class Trainer(NetsPressoBase):
 
         available_options = options_response.data
 
+        # TODO: Will be removed when we support DLC in the future
+        available_options = [
+            available_option
+            for available_option in available_options
+            if available_option.framework != "dlc"
+        ]
+
         return available_options
 
     def _get_status_by_training_summary(self, status):


### PR DESCRIPTION
## Description

Please include a summary in English, of the changes in this pull request. If it closes an issue, please mention it here.

Closes: #345 

You should link at least one existing issue for PR. Before your create a PR, please check to see if there is an issue for this change.  
PRs from forked repository not accepted.

## Change(s)

- Exclude `dlc` framework from available options in trainer metadata.
