### PR TITLE
#459 Add StrEnum for python 3.11

### DIFF
--- a/netspresso/clients/auth/v2/schemas/common.py
+++ b/netspresso/clients/auth/v2/schemas/common.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
-from enum import Enum
+
+from netspresso.enums.base import StrEnum
 
 
 @dataclass
@@ -13,12 +14,12 @@ class PagingResponse(AbstractResponse):
     result_count: int
 
 
-class MembershipType(str, Enum):
+class MembershipType(StrEnum):
     BASIC = "BASIC"
     PRO = "PRO"
     PREMIUM = "PREMIUM"
 
 
-class CreditType(str, Enum):
+class CreditType(StrEnum):
     FREE = "FREE"
     PAID = "PAID"

--- a/netspresso/clients/compressor/v2/schemas/common.py
+++ b/netspresso/clients/compressor/v2/schemas/common.py
@@ -1,14 +1,14 @@
 from dataclasses import dataclass, field
-from enum import Enum
 from typing import List, Optional, Union
 
+from netspresso.enums.base import StrEnum
 from netspresso.enums.device import DisplaySoftwareVersion, HardwareType, SoftwareVersion
 from netspresso.enums.model import DataType, Framework
 from netspresso.metadata import common
 from netspresso.metadata.common import AvailableOption
 
 
-class Order(str, Enum):
+class Order(StrEnum):
     """ """
 
     DESC = "desc"

--- a/netspresso/clients/launcher/v2/schemas/common.py
+++ b/netspresso/clients/launcher/v2/schemas/common.py
@@ -1,17 +1,17 @@
 from dataclasses import dataclass, field
-from enum import Enum
 from pathlib import Path
 from typing import List, Optional, Union
 
 from netspresso.clients.utils.system import ENV_STR
 from netspresso.enums import DataType, DisplaySoftwareVersion, Framework, HardwareType, SoftwareVersion
+from netspresso.enums.base import StrEnum
 from netspresso.metadata import common
 from netspresso.metadata.common import AvailableOption, SoftwareVersions
 
 version = (Path(__file__).parent.parent.parent.parent.parent / "VERSION").read_text().strip()
 
 
-class Order(str, Enum):
+class Order(StrEnum):
     """ """
 
     DESC = "desc"

--- a/netspresso/enums/base.py
+++ b/netspresso/enums/base.py
@@ -1,0 +1,10 @@
+import sys
+from enum import Enum
+
+# Check if running on Python 3.11 or later
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+else:
+    # Define a fallback StrEnum for Python 3.10
+    class StrEnum(str, Enum):
+        pass

--- a/netspresso/enums/compression.py
+++ b/netspresso/enums/compression.py
@@ -1,8 +1,9 @@
-from enum import Enum
 from typing import Literal
 
+from netspresso.enums.base import StrEnum
 
-class CompressionMethod(str, Enum):
+
+class CompressionMethod(StrEnum):
     PR_L2 = "PR_L2"
     PR_GM = "PR_GM"
     PR_NN = "PR_NN"
@@ -17,7 +18,7 @@ class CompressionMethod(str, Enum):
         return Literal["PR_L2", "PR_GM", "PR_NN", "PR_SNP", "PR_ID", "FD_TK", "FD_CP", "FD_SVD"]
 
 
-class RecommendationMethod(str, Enum):
+class RecommendationMethod(StrEnum):
     SLAMP = "slamp"
     VBMF = "vbmf"
 
@@ -26,7 +27,7 @@ class RecommendationMethod(str, Enum):
         return Literal["slamp", "vbmf"]
 
 
-class Policy(str, Enum):
+class Policy(StrEnum):
     SUM = "sum"
     AVERAGE = "average"
 
@@ -35,7 +36,7 @@ class Policy(str, Enum):
         return Literal["sum", "average"]
 
 
-class GroupPolicy(str, Enum):
+class GroupPolicy(StrEnum):
     SUM = "sum"
     AVERAGE = "average"
     COUNT = "count"
@@ -46,7 +47,7 @@ class GroupPolicy(str, Enum):
         return Literal["sum", "average", "count", "none"]
 
 
-class LayerNorm(str, Enum):
+class LayerNorm(StrEnum):
     NONE = "none"
     STANDARD_SCORE = "standard_score"
     TSS_NORM = "tss_norm"
@@ -58,7 +59,7 @@ class LayerNorm(str, Enum):
         return Literal["none", "standard_score", "tss_norm", "linear_scaling", "softmax_norm"]
 
 
-class StepOp(str, Enum):
+class StepOp(StrEnum):
     ROUND_UP = "round_up"
     ROUND_DOWN = "round_down"
     ROUND = "round"

--- a/netspresso/enums/config.py
+++ b/netspresso/enums/config.py
@@ -1,7 +1,7 @@
-from enum import Enum
+from netspresso.enums.base import StrEnum
 
 
-class EnvironmentType(str, Enum):
+class EnvironmentType(StrEnum):
     V2_PROD_CLOUD = "v2-prod-cloud"
     V2_PROD_ON_PREM = "v2-prod-on-prem"
     V2_STAGING_CLOUD = "v2-staging-cloud"
@@ -10,19 +10,19 @@ class EnvironmentType(str, Enum):
     V2_DEV_ON_PREM = "v2-dev-on-prem"
 
 
-class ServiceName(str, Enum):
+class ServiceName(StrEnum):
     NP = "NP"
     TAO = "TAO"
 
 
-class ServiceModule(str, Enum):
+class ServiceModule(StrEnum):
     AUTH = "AUTH"
     COMPRESSOR = "COMPRESSOR"
     LAUNCHER = "LAUNCHER"
     TRAINER = "TRAINER"
 
 
-class EndPointProperty(str, Enum):
+class EndPointProperty(StrEnum):
     HOST = "HOST"
     PORT = "PORT"
     URI_PREFIX = "URI_PREFIX"

--- a/netspresso/enums/credit.py
+++ b/netspresso/enums/credit.py
@@ -1,7 +1,7 @@
-from enum import Enum
+from netspresso.enums.base import StrEnum
 
 
-class ServiceTask(str, Enum):
+class ServiceTask(StrEnum):
     TRAINING = "Training"
     ADVANCED_COMPRESSION = "Advanced Compression"
     AUTOMATIC_COMPRESSION = "Automatic Compression"
@@ -24,7 +24,7 @@ class ServiceCredit:
         return ServiceCredit.CREDITS.get(task_id, "Task not found")
 
 
-class MembershipType(str, Enum):
+class MembershipType(StrEnum):
     BASIC = "BASIC"
     PRO = "PRO"
     PREMIUM = "PREMIUM"

--- a/netspresso/enums/data.py
+++ b/netspresso/enums/data.py
@@ -1,6 +1,6 @@
-from enum import Enum
+from netspresso.enums.base import StrEnum
 
 
-class Format(Enum):
+class Format(StrEnum):
     Local = "local"
     Hugging_Face = "huggingface"

--- a/netspresso/enums/device.py
+++ b/netspresso/enums/device.py
@@ -1,8 +1,9 @@
-from enum import Enum
 from typing import Literal
 
+from netspresso.enums.base import StrEnum
 
-class DeviceName(str, Enum):
+
+class DeviceName(StrEnum):
     RASPBERRY_PI_5 = "RaspberryPi5"
     RASPBERRY_PI_4B = "RaspberryPi4B"
     RASPBERRY_PI_3B_PLUS = "RaspberryPi3BPlus"
@@ -55,50 +56,8 @@ class DeviceName(str, Enum):
             "arduino_nicla_vision",
         ]
 
-    JETSON_DEVICES = [
-        JETSON_NANO,
-        JETSON_TX2,
-        JETSON_XAVIER,
-        JETSON_NX,
-        JETSON_AGX_ORIN,
-        JETSON_ORIN_NANO,
-    ]
-    RASPBERRY_PI_DEVICES = [
-        RASPBERRY_PI_5,
-        RASPBERRY_PI_4B,
-        RASPBERRY_PI_3B,
-        RASPBERRY_PI_2B,
-        RASPBERRY_PI_3B_PLUS,
-        RASPBERRY_PI_ZERO_W,
-        RASPBERRY_PI_ZERO_2W,
-    ]
-    RENESAS_DEVICES = [RENESAS_RZ_V2L, RENESAS_RZ_V2M]
-    NVIDIA_GRAPHIC_CARDS = [AWS_T4]
-    INTEL_DEVICES = [INTEL_XEON_W_2233]
-    AVAILABLE_INT8_DEVICES = [
-        ALIF_ENSEMBLE_E7_DEVKIT_GEN2,
-        RENESAS_RA8D1,
-        RASPBERRY_PI_5,
-        RASPBERRY_PI_4B,
-        RASPBERRY_PI_3B_PLUS,
-        RASPBERRY_PI_3B,
-        RASPBERRY_PI_2B,
-        RASPBERRY_PI_ZERO_W,
-        RASPBERRY_PI_ZERO_2W,
-        ARM_ETHOS_U_SERIES,
-        NXP_iMX93,
-        ARDUINO_NICLA_VISION,
-    ]
-    ONLY_INT8_DEVICES = [
-        ALIF_ENSEMBLE_E7_DEVKIT_GEN2,
-        RENESAS_RA8D1,
-        ARM_ETHOS_U_SERIES,
-        NXP_iMX93,
-        ARDUINO_NICLA_VISION,
-    ]
 
-
-class SoftwareVersion(str, Enum):
+class SoftwareVersion(StrEnum):
     JETPACK_4_4_1 = "4.4.1-b50"
     JETPACK_4_6 = "4.6-b199"
     JETPACK_5_0_1 = "5.0.1-b118"
@@ -110,7 +69,7 @@ class SoftwareVersion(str, Enum):
         return Literal["4.4.1-b50", "4.6-b199", "5.0.1-b118", "5.0.2-b231", "6.0-b52"]
 
 
-class DisplaySoftwareVersion(str, Enum):
+class DisplaySoftwareVersion(StrEnum):
     JETPACK_4_4_1 = "Jetpack 4.4.1"
     JETPACK_4_6 = "Jetpack 4.6"
     JETPACK_5_0_1 = "Jetpack 5.0.1"
@@ -118,7 +77,7 @@ class DisplaySoftwareVersion(str, Enum):
     JETPACK_6_0 = "Jetpack 6.0"
 
 
-class HardwareType(str, Enum):
+class HardwareType(StrEnum):
     HELIUM = "helium"
 
     @classmethod
@@ -126,7 +85,7 @@ class HardwareType(str, Enum):
         return Literal["helium"]
 
 
-class TaskStatus(str, Enum):
+class TaskStatus(StrEnum):
     IN_QUEUE = "IN_QUEUE"
     IN_PROGRESS = "IN_PROGRESS"
     FINISHED = "FINISHED"

--- a/netspresso/enums/inference.py
+++ b/netspresso/enums/inference.py
@@ -1,9 +1,8 @@
-from enum import Enum
-
+from netspresso.enums.base import StrEnum
 from netspresso.exceptions.inferencer import NotSupportedSuffixException
 
 
-class Runtime(str, Enum):
+class Runtime(StrEnum):
     ONNX = "onnx"
     TFLITE = "tflite"
 

--- a/netspresso/enums/metadata.py
+++ b/netspresso/enums/metadata.py
@@ -1,7 +1,7 @@
-from enum import Enum
+from netspresso.enums.base import StrEnum
 
 
-class TaskType(str, Enum):
+class TaskType(StrEnum):
     TRAIN = "train"
     COMPRESS = "compress"
     CONVERT = "convert"
@@ -9,7 +9,7 @@ class TaskType(str, Enum):
     BENCHMARK = "benchmark"
 
 
-class Status(str, Enum):
+class Status(StrEnum):
     IN_PROGRESS = "in_progress"
     COMPLETED = "completed"
     STOPPED = "stopped"

--- a/netspresso/enums/model.py
+++ b/netspresso/enums/model.py
@@ -1,8 +1,9 @@
-from enum import Enum
 from typing import Literal
 
+from netspresso.enums.base import StrEnum
 
-class Framework(str, Enum):
+
+class Framework(StrEnum):
     TENSORFLOW_KERAS = "tensorflow_keras"
     TENSORFLOW = "saved_model"
     PYTORCH = "pytorch"
@@ -29,7 +30,7 @@ class Framework(str, Enum):
         ]
 
 
-class Extension(str, Enum):
+class Extension(StrEnum):
     H5 = "h5"
     ZIP = "zip"
     PT = "pt"
@@ -40,7 +41,7 @@ class Extension(str, Enum):
         return Literal["h5", "zip", "pt", "onnx"]
 
 
-class OriginFrom(str, Enum):
+class OriginFrom(StrEnum):
     CUSTOM = "custom"
     NPMS = "npms"
 
@@ -49,7 +50,7 @@ class OriginFrom(str, Enum):
         return Literal["custom", "npms"]
 
 
-class DataType(str, Enum):
+class DataType(StrEnum):
     FP32 = "FP32"
     FP16 = "FP16"
     INT8 = "INT8"

--- a/netspresso/enums/module.py
+++ b/netspresso/enums/module.py
@@ -1,8 +1,9 @@
-from enum import Enum
 from typing import Literal
 
+from netspresso.enums.base import StrEnum
 
-class Module(str, Enum):
+
+class Module(StrEnum):
     CONVERT = "CONVERT"
     BENCHMARK = "BENCHMARK"
 

--- a/netspresso/enums/quantize.py
+++ b/netspresso/enums/quantize.py
@@ -1,13 +1,13 @@
-from enum import Enum
+from netspresso.enums.base import StrEnum
 
 
-class QuantizationPrecision(str, Enum):
+class QuantizationPrecision(StrEnum):
     INT8 = "int8"
     FLOAT16 = "float16"
     FLOAT32 = "float32"
 
 
-class QuantizationMode(str, Enum):
+class QuantizationMode(StrEnum):
     AUTOMATIC_QUANTIZATION = "automatic_quantization"
     UNIFORM_PRECISION_QUANTIZATION = "uniform_precision_quantization"
     CUSTOM_PRECISION_QUANTIZATION = "custom_precision_quantization"
@@ -15,11 +15,11 @@ class QuantizationMode(str, Enum):
     RECOMMEND_QUANTIZATION = "recommend_quantization"
 
 
-class SimilarityMetric(str, Enum):
+class SimilarityMetric(StrEnum):
     SNR = "SNR"
 
 
-class OnnxOperator(str, Enum):
+class OnnxOperator(StrEnum):
     Adagrad = "Adagrad"
     Momentum = "Momentum"
     ZipMap = "ZipMap"

--- a/netspresso/enums/tao/action.py
+++ b/netspresso/enums/tao/action.py
@@ -1,7 +1,7 @@
-from enum import Enum
+from netspresso.enums.base import StrEnum
 
 
-class ExperimentAction(str, Enum):
+class ExperimentAction(StrEnum):
     TRAIN = "train"
     EVALUATE = "evaluate"
     EXPORT = "export"
@@ -11,7 +11,7 @@ class ExperimentAction(str, Enum):
     INFERENCE = "inference"
 
 
-class ConvertAction(str, Enum):
+class ConvertAction(StrEnum):
     DATASET_CONVERT = "dataset_convert"
     CONVERT = "convert"
     CONVERT_AND_INDEX = "convert_and_index"

--- a/netspresso/enums/tao/experiment.py
+++ b/netspresso/enums/tao/experiment.py
@@ -1,19 +1,19 @@
-from enum import Enum
+from netspresso.enums.base import StrEnum
 
 
-class EncryptionKey(str, Enum):
+class EncryptionKey(StrEnum):
     NVIDIA_TAO = "nvidia_tao"
     NVIDIA_TLT = "nvidia_tlt"
     TLT_ENCODE = "tlt_encode"
 
 
-class CheckpointChooseMethod(str, Enum):
+class CheckpointChooseMethod(StrEnum):
     LATEST_MODEL = "latest_model"
     BEST_MODEL = "best_model"
     FROM_EPOCH_NUMBER = "from_epoch_number"
 
 
-class NetworkArch(str, Enum):
+class NetworkArch(StrEnum):
     CLASSIFICATION_TF1 = "classification_tf1"
     CLASSIFICATION_TF2 = "classification_tf2"
     CLASSIFICATION_PYT = "classification_pyt"

--- a/netspresso/enums/task.py
+++ b/netspresso/enums/task.py
@@ -1,15 +1,15 @@
-from enum import Enum
-
 from aenum import NamedConstant
 
+from netspresso.enums.base import StrEnum
 
-class Task(str, Enum):
+
+class Task(StrEnum):
     IMAGE_CLASSIFICATION = "classification"
     OBJECT_DETECTION = "detection"
     SEMANTIC_SEGMENTATION = "segmentation"
 
 
-class LauncherTask(str, Enum):
+class LauncherTask(StrEnum):
     CONVERT = "convert"
     BENCHMARK = "benchmark"
     QUANTIZE = "quantize"

--- a/netspresso/enums/train.py
+++ b/netspresso/enums/train.py
@@ -1,7 +1,7 @@
-from enum import Enum
+from netspresso.enums.base import StrEnum
 
 
-class Optimizer(str, Enum):
+class Optimizer(StrEnum):
     ADADELTA = "Adadelta"
     ADAGRAD = "Adagrad"
     ADAM = "Adam"
@@ -24,7 +24,7 @@ class Optimizer(str, Enum):
         return name_map[name.lower()].value
 
 
-class Scheduler(str, Enum):
+class Scheduler(StrEnum):
     STEPLR = "StepLR"
     POLYNOMIAL_LR_WITH_WARM_UP = "PolynomialLRWithWarmUp"
     COSINE_ANNEALING_LR_WITH_CUSTOM_WARM_UP = "CosineAnnealingLRWithCustomWarmUp"

--- a/netspresso/exceptions/common.py
+++ b/netspresso/exceptions/common.py
@@ -1,9 +1,10 @@
 from dataclasses import asdict, dataclass, field
-from enum import Enum
 from typing import List, Optional
 
+from netspresso.enums.base import StrEnum
 
-class LinkType(str, Enum):
+
+class LinkType(StrEnum):
     DOCS = "docs"
     CONTACT = "contact"
 

--- a/netspresso/np_qai/options/common.py
+++ b/netspresso/np_qai/options/common.py
@@ -1,9 +1,10 @@
 from dataclasses import dataclass
-from enum import Enum
 from typing import List, Optional
 
+from netspresso.enums.base import StrEnum
 
-class ComputeUnit(str, Enum):
+
+class ComputeUnit(StrEnum):
     ALL = "all"
     NPU = "npu"
     GPU = "gpu"

--- a/netspresso/np_qai/options/compile.py
+++ b/netspresso/np_qai/options/compile.py
@@ -1,11 +1,11 @@
 from dataclasses import dataclass
-from enum import Enum
 from typing import Optional
 
+from netspresso.enums.base import StrEnum
 from netspresso.np_qai.options.common import CommonOptions
 
 
-class Framework(str, Enum):
+class Framework(StrEnum):
     PYTORCH = "pytorch"
     ONNX = "onnx"
     ONNXRUNTIME = "onnxruntime"
@@ -17,14 +17,14 @@ class Framework(str, Enum):
     QNN = "qnn"
 
 
-class Extension(str, Enum):
+class Extension(StrEnum):
     ONNX = ".onnx"
     PT = ".pt"
     AIMET = ".aimet"
     H5 = ".h5"
 
 
-class Runtime(str, Enum):
+class Runtime(StrEnum):
     TFLITE = "tflite"
     QNN_LIB_AARCH64_ANDROID = "qnn_lib_aarch64_android"
     QNN_CONTEXT_BINARY = "qnn_context_binary"
@@ -32,7 +32,7 @@ class Runtime(str, Enum):
     PRECOMPILED_QNN_ONNX = "precompiled_qnn_onnx"
 
 
-class QuantizeFullType(str, Enum):
+class QuantizeFullType(StrEnum):
     INT8 = "int8"
     INT16 = "int16"
     W8A16 = "w8a16"
@@ -40,7 +40,7 @@ class QuantizeFullType(str, Enum):
     W4A16 = "w4a16"
 
 
-class QuantizeWeightType(str, Enum):
+class QuantizeWeightType(StrEnum):
     FP16 = "float16"
 
 

--- a/netspresso/np_qai/options/profile.py
+++ b/netspresso/np_qai/options/profile.py
@@ -1,11 +1,11 @@
 from dataclasses import dataclass, field
-from enum import Enum
 from typing import List, Optional, Union
 
+from netspresso.enums.base import StrEnum
 from netspresso.np_qai.options.common import CommonOptions
 
 
-class TfliteDelegates(str, Enum):
+class TfliteDelegates(StrEnum):
     QNN = "qnn"
     QNN_GPU = "qnn-gpu"
     NNAPI = "nnapi"
@@ -14,19 +14,19 @@ class TfliteDelegates(str, Enum):
     XNNPACK = "xnnpack"
 
 
-class ExecutionMode(str, Enum):
+class ExecutionMode(StrEnum):
     SEQUENTIAL = "SEQUENTIAL"
     PARALLEL = "PARALLEL"
 
 
-class GraphOptimizationLevel(str, Enum):
+class GraphOptimizationLevel(StrEnum):
     DISABLE_ALL = "DISABLE_ALL"
     ENABLE_BASIC = "ENABLE_BASIC"
     ENABLE_EXTENDED = "ENABLE_EXTENDED"
     ENABLE_ALL = "ENABLE_ALL"
 
 
-class OnnxQnnHtpPerformanceMode(str, Enum):
+class OnnxQnnHtpPerformanceMode(StrEnum):
     DEFAULT = "default"
     LOW_POWER_SAVER = "low_power_saver"
     POWER_SAVER = "power_saver"
@@ -38,13 +38,13 @@ class OnnxQnnHtpPerformanceMode(str, Enum):
     BURST = "burst"
 
 
-class OnnxExecutionProviders(str, Enum):
+class OnnxExecutionProviders(StrEnum):
     QNN = "qnn"
     QNN_GPU = "qnn-gpu"
     DIRECTML = "directml"
 
 
-class QnnLogLevel(str, Enum):
+class QnnLogLevel(StrEnum):
     K_LOG_OFF = "kLogOff"
     K_LOG_LEVEL_ERROR = "kLogLevelError"
     K_LOG_LEVEL_WARN = "kLogLevelWarn"
@@ -53,7 +53,7 @@ class QnnLogLevel(str, Enum):
     K_LOG_LEVEL_DEBUG = "kLogLevelDebug"
 
 
-class QnnGraphPriority(str, Enum):
+class QnnGraphPriority(StrEnum):
     K_QNN_PRIORITY_DEFAULT = "kQnnPriorityDefault"
     K_QNN_PRIORITY_LOW = "kQnnPriorityLow"
     K_QNN_PRIORITY_NORMAL = "kQnnPriorityNormal"
@@ -62,21 +62,21 @@ class QnnGraphPriority(str, Enum):
     K_QNN_PRIORITY_UNDEFINED = "kQnnPriorityUndefined"
 
 
-class QnnGpuPrecision(str, Enum):
+class QnnGpuPrecision(StrEnum):
     K_GPU_USER_PROVIDED = "kGpuUserProvided"
     K_GPU_FP32 = "kGpuFp32"
     K_GPU_FP16 = "kGpuFp16"
     K_GPU_HYBRID = "kGpuHybrid"
 
 
-class QnnGpuPerformanceMode(str, Enum):
+class QnnGpuPerformanceMode(StrEnum):
     K_GPU_DEFAULT = "kGpuDefault"
     K_GPU_HIGH = "kGpuHigh"
     K_GPU_NORMAL = "kGpuNormal"
     K_GPU_LOW = "kGpuLow"
 
 
-class QnnDspPerformanceMode(str, Enum):
+class QnnDspPerformanceMode(StrEnum):
     K_DSP_LOW_POWER_SAVER = "kDspLowPowerSaver"
     K_DSP_POWER_SAVER = "kDspPowerSaver"
     K_DSP_HIGH_POWER_SAVER = "kDspHighPowerSaver"
@@ -87,12 +87,12 @@ class QnnDspPerformanceMode(str, Enum):
     K_DSP_BURST = "kDspBurst"
 
 
-class QnnDspEncoding(str, Enum):
+class QnnDspEncoding(StrEnum):
     K_DSP_STATIC = "kDspStatic"
     K_DSP_DYNAMIC = "kDspDynamic"
 
 
-class TfliteQnnHtpPerformanceMode(str, Enum):
+class TfliteQnnHtpPerformanceMode(StrEnum):
     K_HTP_LOW_POWER_SAVER = "kHtpLowPowerSaver"
     K_HTP_POWER_SAVER = "kHtpPowerSaver"
     K_HTP_HIGH_POWER_SAVER = "kHtpHighPowerSaver"
@@ -103,54 +103,54 @@ class TfliteQnnHtpPerformanceMode(str, Enum):
     K_HTP_BURST = "kHtpBurst"
 
 
-class QnnHtpPrecision(str, Enum):
+class QnnHtpPrecision(StrEnum):
     K_HTP_QUANTIZED = "kHtpQuantized"
     K_HTP_FP16 = "kHtpFp16"
 
 
-class QnnHtpOptimizationStrategy(str, Enum):
+class QnnHtpOptimizationStrategy(StrEnum):
     K_HTP_OPTIMIZE_FOR_INFERENCE = "kHtpOptimizeForInference"
     K_HTP_OPTIMIZE_FOR_PREPARE = "kHtpOptimizeForPrepare"
 
 
-class GpuInferencePreference(str, Enum):
+class GpuInferencePreference(StrEnum):
     TFLITE_GPU_INFERENCE_PREFERENCE_FAST_SINGLE_ANSWER = "TFLITE_GPU_INFERENCE_PREFERENCE_FAST_SINGLE_ANSWER"
     TFLITE_GPU_INFERENCE_PREFERENCE_SUSTAINED_SPEED = "TFLITE_GPU_INFERENCE_PREFERENCE_SUSTAINED_SPEED"
     TFLITE_GPU_INFERENCE_PREFERENCE_BALANCED = "TFLITE_GPU_INFERENCE_PREFERENCE_BALANCED"
 
 
-class GpuInferencePriority(str, Enum):
+class GpuInferencePriority(StrEnum):
     TFLITE_GPU_INFERENCE_PREFERENCE_BALANCED = "TFLITE_GPU_INFERENCE_PREFERENCE_BALANCED"
     TFLITE_GPU_INFERENCE_PRIORITY_MAX_PRECISION = "TFLITE_GPU_INFERENCE_PRIORITY_MAX_PRECISION"
     TFLITE_GPU_INFERENCE_PRIORITY_MIN_LATENCY = "TFLITE_GPU_INFERENCE_PRIORITY_MIN_LATENCY"
     TFLITE_GPU_INFERENCE_PRIORITY_MIN_MEMORY_USAGE = "TFLITE_GPU_INFERENCE_PRIORITY_MIN_MEMORY_USAGE"
 
 
-class NnapiExecutionPreference(str, Enum):
+class NnapiExecutionPreference(StrEnum):
     K_LOW_POWER = "kLowPower"
     K_FAST_SINGLE_ANSWER = "kFastSingleAnswer"
     K_SUSTAINED_SPEED = "kSustainedSpeed"
 
 
-class ContextErrorReportingOptionsLevel(str, Enum):
+class ContextErrorReportingOptionsLevel(StrEnum):
     BRIEF = "BRIEF"
     DETAILED = "DETAILED"
 
 
-class Priority(str, Enum):
+class Priority(StrEnum):
     LOW = "LOW"
     NORMAL = "NORMAL"
     NORMAL_HIGH = "NORMAL_HIGH"
     HIGH = "HIGH"
 
 
-class ContextGpuPerformanceHint(str, Enum):
+class ContextGpuPerformanceHint(StrEnum):
     LOW = "LOW"
     NORMAL = "NORMAL"
     HIGH = "HIGH"
 
 
-class ContextHtpPerformanceMode(str, Enum):
+class ContextHtpPerformanceMode(StrEnum):
     EXTREME_POWER_SAVER = "EXTREME_POWER_SAVER"
     LOW_POWER_SAVER = "LOW_POWER_SAVER"
     POWER_SAVER = "POWER_SAVER"
@@ -162,18 +162,18 @@ class ContextHtpPerformanceMode(str, Enum):
     BURST = "BURST"
 
 
-class DefaultGraphGpuPrecision(str, Enum):
+class DefaultGraphGpuPrecision(StrEnum):
     FLOAT32 = "FLOAT32"
     FLOAT16 = "FLOAT16"
     HYBRID = "HYBRID"
     USER_PROVIDED = "USER_PROVIDED"
 
 
-class DefaultGraphHtpOptimizationType(str, Enum):
+class DefaultGraphHtpOptimizationType(StrEnum):
     FINALIZE_OPTIMIZATION_FLAG = "FINALIZE_OPTIMIZATION_FLAG"
 
 
-class DefaultGraphHtpPrecision(str, Enum):
+class DefaultGraphHtpPrecision(StrEnum):
     FLOAT16 = "FLOAT16"
 
 

--- a/netspresso/np_qai/options/quantize.py
+++ b/netspresso/np_qai/options/quantize.py
@@ -1,11 +1,12 @@
 from dataclasses import dataclass
-from enum import Enum
 from typing import Optional
 
 from qai_hub import QuantizeDtype
 
+from netspresso.enums.base import StrEnum
 
-class RangeScheme(str, Enum):
+
+class RangeScheme(StrEnum):
     AUTO = "auto"
     MSE_MINIMIZER = "mse_minimizer"
     MIN_MAX = "min_max"


### PR DESCRIPTION
## Description

Please include a summary in English, of the changes in this pull request. If it closes an issue, please mention it here.

Add backward compatibility for `StrEnum` which is only available in Python 3.11+. This change allows the codebase to use `StrEnum` consistently across different Python versions.

Closes: #459

You should link at least one existing issue for PR. Before your create a PR, please check to see if there is an issue for this change.  
PRs from forked repository not accepted.

## Change(s)

- Add StrEnum for python 3.11.
  - For Python 3.11+: Uses the native `StrEnum` from the `enum` module
  - For Python 3.10 and below: Implements a custom `StrEnum` class that inherits from `str` and `Enum`
