### PR TITLE
Replace API key with access token for DataForge client auth

### DIFF
--- a/netspresso/clients/dataforge/main.py
+++ b/netspresso/clients/dataforge/main.py
@@ -1,5 +1,3 @@
-import os
-
 from netspresso.clients.config import Config, ServiceModule, ServiceName
 from netspresso.clients.dataforge.schemas.response_body import (
     DatasetResponse,
@@ -7,16 +5,8 @@ from netspresso.clients.dataforge.schemas.response_body import (
     DatasetVersionResponse,
     DatasetVersionsResponse,
 )
+from netspresso.clients.utils.common import get_headers
 from netspresso.clients.utils.requester import Requester
-
-
-def get_headers(api_key=None, json_type=False):
-    headers = {}
-    if api_key:
-        headers["api_key"] = f"{api_key}"
-    if json_type:
-        headers["Content-Type"] = "application/json"
-    return headers
 
 
 class DataForgeClient:
@@ -25,41 +15,40 @@ class DataForgeClient:
         self.host = self.config.HOST
         self.port = self.config.PORT
         self.prefix = self.config.URI_PREFIX
-        self.api_key = os.getenv("DATAFORGE_API_KEY")
 
         if https:
             self.url = f"https://{self.host}:{self.port}{self.prefix}"
         else:
             self.url = f"http://{self.host}:{self.port}{self.prefix}"
 
-    def get_datasets(self, project_id: str) -> DatasetsResponse:
+    def get_datasets(self, project_id: str, access_token: str) -> DatasetsResponse:
         url = f"{self.url}/dataset/{project_id}"
 
         # TODO: Remove verify=False in production. This is only for testing purposes.
-        response = Requester.get(url=url, headers=get_headers(self.api_key), verify=False)
+        response = Requester.get(url=url, headers=get_headers(access_token), verify=False)
 
         return DatasetsResponse(**response.json())
 
-    def get_dataset(self, project_id: str, dataset_uuid: str) -> DatasetResponse:
+    def get_dataset(self, project_id: str, dataset_uuid: str, access_token: str) -> DatasetResponse:
         url = f"{self.url}/dataset/{project_id}/{dataset_uuid}"
 
         # TODO: Remove verify=False in production. This is only for testing purposes.
-        response = Requester.get(url=url, headers=get_headers(self.api_key), verify=False)
+        response = Requester.get(url=url, headers=get_headers(access_token), verify=False)
 
         return DatasetResponse(**response.json())
 
-    def get_dataset_versions(self, dataset_uuid: str, split: str) -> DatasetVersionsResponse:
+    def get_dataset_versions(self, dataset_uuid: str, split: str, access_token: str) -> DatasetVersionsResponse:
         url = f"{self.url}/dataset/version/{dataset_uuid}/{split}/all"
 
         # TODO: Remove verify=False in production. This is only for testing purposes.
-        response = Requester.get(url=url, headers=get_headers(self.api_key), verify=False)
+        response = Requester.get(url=url, headers=get_headers(access_token), verify=False)
 
         return DatasetVersionsResponse(**response.json())
 
-    def get_latest_dataset_version(self, dataset_uuid: str, split: str) -> DatasetVersionResponse:
+    def get_latest_dataset_version(self, dataset_uuid: str, split: str, access_token: str) -> DatasetVersionResponse:
         url = f"{self.url}/dataset/version/{dataset_uuid}/{split}/latest"
 
         # TODO: Remove verify=False in production. This is only for testing purposes.
-        response = Requester.get(url=url, headers=get_headers(self.api_key), verify=False)
+        response = Requester.get(url=url, headers=get_headers(access_token), verify=False)
 
         return DatasetVersionResponse(**response.json())

--- a/netspresso/trainer/storage/dataforge.py
+++ b/netspresso/trainer/storage/dataforge.py
@@ -31,21 +31,21 @@ class DataForge:
         self.annotation_bucket = "annotations"
         self.csv_bucket = "dataset"
 
-    def get_datasets(self, project_id: str) -> DatasetsResponse:
+    def get_datasets(self, project_id: str, access_token: str) -> DatasetsResponse:
         """Get all datasets in a project"""
-        return self.client.get_datasets(project_id)
+        return self.client.get_datasets(project_id, access_token)
 
-    def get_dataset(self, dataset_uuid: str, split: str) -> DatasetResponse:
+    def get_dataset(self, dataset_uuid: str, split: str, access_token: str) -> DatasetResponse:
         """Get a specific dataset by UUID and split"""
-        return self.client.get_dataset(dataset_uuid, split)
+        return self.client.get_dataset(dataset_uuid, split, access_token)
 
-    def get_dataset_versions(self, dataset_uuid: str, split: str) -> DatasetVersionsResponse:
+    def get_dataset_versions(self, dataset_uuid: str, split: str, access_token: str) -> DatasetVersionsResponse:
         """Get all versions of a dataset by UUID and split"""
-        return self.client.get_dataset_versions(dataset_uuid, split)
+        return self.client.get_dataset_versions(dataset_uuid, split, access_token)
 
-    def get_latest_dataset_version(self, dataset_uuid: str, split: str) -> DatasetVersionResponse:
+    def get_latest_dataset_version(self, dataset_uuid: str, split: str, access_token: str) -> DatasetVersionResponse:
         """Get the latest version of a dataset by UUID and split"""
-        return self.client.get_latest_dataset_version(dataset_uuid, split)
+        return self.client.get_latest_dataset_version(dataset_uuid, split, access_token)
 
     def _download_csv_file(self, csv_path: str, dataset_dir: Path) -> bool:
         """

--- a/netspresso/trainer/storage/dataset_manager.py
+++ b/netspresso/trainer/storage/dataset_manager.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from loguru import logger
 from tqdm import tqdm
 
+from netspresso.clients.auth.client import TokenHandler
 from netspresso.clients.dataforge.schemas.response_body import DatasetVersionResponse
 from netspresso.exceptions.dataset import DatasetDownloadError, DatasetNotFoundError, DatasetPrepareError
 from netspresso.trainer.storage.dataforge import Split, dataforge
@@ -19,8 +20,8 @@ class DatasetManager:
     and preparing datasets for training and evaluation.
     """
 
-    def __init__(self, token_handler: Optional[Any] = None) -> None:
-        self.token_handler: Optional[Any] = token_handler
+    def __init__(self, token_handler: TokenHandler) -> None:
+        self.token_handler: TokenHandler = token_handler
 
     def _check_dataset_exists(self, dataset_dir: Path, split: str) -> bool:
         """
@@ -201,7 +202,11 @@ class DatasetManager:
 
         for attempt in range(max_retries):
             try:
-                dataset_version = dataforge.get_latest_dataset_version(dataset_uuid=dataset_uuid, split=split)
+                dataset_version = dataforge.get_latest_dataset_version(
+                    dataset_uuid=dataset_uuid,
+                    split=split,
+                    access_token=self.token_handler.tokens.access_token,
+                )
                 if not dataset_version or not dataset_version.data:
                     logger.error(f"Could not get dataset info for UUID: {dataset_uuid}, split: {split}")
                     permanent_error = True


### PR DESCRIPTION
## Description

Please include a summary in English, of the changes in this pull request. If it closes an issue, please mention it here.

Closes: #(issue)

You should link at least one existing issue for PR. Before your create a PR, please check to see if there is an issue for this change.  
PRs from forked repository not accepted.

## Change(s)

- Change the authentication method for the DataForge client to use an access token instead of an API key.
