### PR TITLE
Improve conversion workflow by reusing existing tasks and simplifying retrieval

### DIFF
--- a/app/services/conversion_task.py
+++ b/app/services/conversion_task.py
@@ -84,6 +84,38 @@ class ConversionTaskService:
     def create_conversion_task(
         self, db: Session, conversion_in: ConversionCreate, api_key: str
     ) -> ConversionCreatePayload:
+        # Check if a task with the same options already exists
+        existing_tasks = conversion_task_repository.get_all_by_model_id(
+            db=db,
+            model_id=conversion_in.input_model_id
+        )
+
+        # Filter tasks by conversion parameters
+        for task in existing_tasks:
+            # Check if this task has the same conversion parameters
+            is_same_options = (
+                task.framework == conversion_in.framework and
+                task.device_name == conversion_in.device_name and
+                task.precision == conversion_in.precision
+            )
+
+            # Software version can be None, handle it separately
+            is_same_software_version = (
+                conversion_in.software_version is None or
+                task.software_version == conversion_in.software_version
+            )
+
+            if is_same_options and is_same_software_version:
+                # If task is in NOT_STARTED, IN_PROGRESS, or COMPLETED state, return it
+                reusable_states = [Status.NOT_STARTED, Status.IN_PROGRESS, Status.COMPLETED]
+                if task.status in reusable_states:
+                    logger.info(f"Returning existing conversion task with status {task.status}: {task.task_id}")
+                    return ConversionCreatePayload(task_id=task.task_id)
+
+                # For STOPPED or ERROR, we'll create a new task below
+                logger.info(f"Previous conversion task ended with status {task.status}, creating new task")
+                break
+
         # Get model from trained models repository
         model = model_repository.get_by_model_id(db=db, model_id=conversion_in.input_model_id)
         project = project_service.get_project(db=db, project_id=model.project_id, api_key=api_key)

--- a/app/services/model.py
+++ b/app/services/model.py
@@ -26,28 +26,19 @@ class ModelService:
         self.BUCKET_NAME = settings.MODEL_BUCKET_NAME
 
     def _get_conversion_info(self, db: Session, model_id: str) -> tuple[Optional[str], List[str], List[str]]:
+        # Get all conversion tasks sorted by creation time (newest first)
         conversion_tasks = conversion_task_repository.get_all_by_model_id(
             db=db, model_id=model_id, order=Order.DESC, time_sort=TimeSort.CREATED_AT,
         )
 
-        unique_option_tasks = {}
-
-        for task in conversion_tasks:
-            option_key = (task.framework, task.device_name, task.software_version, task.precision)
-
-            if option_key not in unique_option_tasks:
-                unique_option_tasks[option_key] = task
-
-        filtered_tasks = list(unique_option_tasks.values())
-
         task_ids = []
         model_ids = []
 
-        for task in filtered_tasks:
+        for task in conversion_tasks:
             task_ids.append(task.task_id)
             model_ids.append(task.model_id)
 
-        latest_status = filtered_tasks[0].status if filtered_tasks else None
+        latest_status = conversion_tasks[0].status if conversion_tasks else None
 
         return latest_status, task_ids, model_ids
 

--- a/app/services/model.py
+++ b/app/services/model.py
@@ -27,14 +27,13 @@ class ModelService:
 
     def _get_conversion_info(self, db: Session, model_id: str) -> tuple[Optional[str], List[str], List[str]]:
         conversion_tasks = conversion_task_repository.get_all_by_model_id(
-            db=db, model_id=model_id, order=Order.ASC, time_sort=TimeSort.CREATED_AT,
+            db=db, model_id=model_id, order=Order.DESC, time_sort=TimeSort.CREATED_AT,
         )
 
         unique_option_tasks = {}
 
         for task in conversion_tasks:
-            option_key = (task.framework, task.device_name,
-                        task.software_version, task.precision)
+            option_key = (task.framework, task.device_name, task.software_version, task.precision)
 
             if option_key not in unique_option_tasks:
                 unique_option_tasks[option_key] = task


### PR DESCRIPTION
## Description

Please include a summary in English, of the changes in this pull request. If it closes an issue, please mention it here.

Closes: #(issue)

You should link at least one existing issue for PR. Before your create a PR, please check to see if there is an issue for this change.  
PRs from forked repository not accepted.

## Change(s)

- Add logic to reuse existing conversion tasks based on parameters and status.
- Refactor conversion task retrieval to remove unique filtering and directly use sorted tasks.
