### PR TITLE
Pre-generate benchmark and conversion task IDs before starting Celery workers

### DIFF
--- a/app/services/benchmark_task.py
+++ b/app/services/benchmark_task.py
@@ -27,6 +27,7 @@ from netspresso.enums.model import Framework
 from netspresso.enums.project import SubFolder
 from netspresso.enums.task import TaskStatusForDisplay
 from netspresso.netspresso import NetsPresso
+from netspresso.utils.db.models.base import generate_uuid
 from netspresso.utils.db.models.benchmark import BenchmarkTask
 from netspresso.utils.db.repositories.benchmark import benchmark_task_repository
 from netspresso.utils.db.repositories.conversion import conversion_task_repository
@@ -128,7 +129,8 @@ class BenchmarkTaskService:
         input_model_path = Path(project.project_abs_path) / model.object_path
         logger.info(f"Input model path: {input_model_path}")
 
-        task = benchmark_model.apply_async(
+        benchmark_task_id = generate_uuid(entity="task")
+        _ = benchmark_model.apply_async(
             kwargs={
                 "api_key": api_key,
                 "input_model_path": input_model_path.as_posix(),
@@ -137,9 +139,10 @@ class BenchmarkTaskService:
                 "target_hardware_type": benchmark_in.hardware_type,
                 "input_model_id": benchmark_in.input_model_id,
             },
+            benchmark_task_id=benchmark_task_id,
         )
 
-        return BenchmarkCreatePayload(task_id=task.get())
+        return BenchmarkCreatePayload(task_id=benchmark_task_id)
 
     def get_benchmark_task(self, db: Session, task_id: str, api_key: str) -> BenchmarkResponse:
         """Get benchmark task status and details"""

--- a/app/services/conversion_task.py
+++ b/app/services/conversion_task.py
@@ -24,6 +24,7 @@ from netspresso.clients.launcher.v2.schemas.common import DeviceInfo
 from netspresso.enums import Status, TaskStatusForDisplay
 from netspresso.enums.conversion import SourceFramework
 from netspresso.netspresso import NetsPresso
+from netspresso.utils.db.models.base import generate_uuid
 from netspresso.utils.db.models.conversion import ConversionTask
 from netspresso.utils.db.repositories.conversion import conversion_task_repository
 from netspresso.utils.db.repositories.model import model_repository
@@ -130,7 +131,8 @@ class ConversionTaskService:
         logger.info(f"Conversion Info: {conversion_in.model_dump()}")
         logger.info(f"Output dir: {output_dir}")
 
-        task = convert_model.apply_async(
+        conversion_task_id = generate_uuid(entity="task")
+        _ = convert_model.apply_async(
             kwargs={
                 "api_key": api_key,
                 "input_model_path": input_model_path.as_posix(),
@@ -141,9 +143,9 @@ class ConversionTaskService:
                 "target_software_version": conversion_in.software_version,
                 "input_model_id": conversion_in.input_model_id,
             },
+            conversion_task_id=conversion_task_id,
         )
-        task_id = task.get()
-        return ConversionCreatePayload(task_id=task_id)
+        return ConversionCreatePayload(task_id=conversion_task_id)
 
     def get_conversion_task(self, db: Session, task_id: str, api_key: str) -> ConversionPayload:
         conversion_task = conversion_task_repository.get_by_task_id(db, task_id)

--- a/app/worker/benchmark_task.py
+++ b/app/worker/benchmark_task.py
@@ -15,6 +15,7 @@ def benchmark_model(
     target_software_version: str = None,
     target_hardware_type: str = None,
     input_model_id: str = None,
+    benchmark_task_id: str = None,
 ):
     netspresso = NetsPresso(api_key=api_key)
 
@@ -25,6 +26,7 @@ def benchmark_model(
         target_software_version=target_software_version,
         target_hardware_type=target_hardware_type,
         input_model_id=input_model_id,
+        benchmark_task_id=benchmark_task_id,
         wait_until_done=False,
     )
 

--- a/app/worker/conversion_task.py
+++ b/app/worker/conversion_task.py
@@ -19,6 +19,7 @@ def convert_model(
     input_layer=None,
     dataset_path: str = None,
     input_model_id: str = None,
+    conversion_task_id: str = None,
 ):
     netspresso = NetsPresso(api_key=api_key)
 
@@ -33,6 +34,7 @@ def convert_model(
         input_layer=input_layer,
         dataset_path=dataset_path,
         input_model_id=input_model_id,
+        conversion_task_id=conversion_task_id,
         wait_until_done=False,
     )
 

--- a/netspresso/benchmarker/v2/benchmarker.py
+++ b/netspresso/benchmarker/v2/benchmarker.py
@@ -194,18 +194,32 @@ class BenchmarkerV2(NetsPressoBase):
         data_type: Union[str, DataType],
         input_model_id: Optional[str] = None,
         model_id: Optional[str] = None,
+        benchmark_task_id: Optional[str] = None,
     ) -> BenchmarkTask:
         with get_db_session() as db:
-            benchmark_task = BenchmarkTask(
-                framework=framework,
-                device_name=device_name,
-                software_version=software_version,
-                precision=data_type,
-                status=Status.NOT_STARTED,
-                input_model_id=input_model_id,
-                model_id=model_id,
-                user_id=self.user_info.user_id,
-            )
+            if benchmark_task_id:
+                benchmark_task = BenchmarkTask(
+                    task_id=benchmark_task_id,
+                    framework=framework,
+                    device_name=device_name,
+                    software_version=software_version,
+                    precision=data_type,
+                    status=Status.NOT_STARTED,
+                    input_model_id=input_model_id,
+                    model_id=model_id,
+                    user_id=self.user_info.user_id,
+                )
+            else:
+                benchmark_task = BenchmarkTask(
+                    framework=framework,
+                    device_name=device_name,
+                    software_version=software_version,
+                    precision=data_type,
+                    status=Status.NOT_STARTED,
+                    input_model_id=input_model_id,
+                    model_id=model_id,
+                    user_id=self.user_info.user_id,
+                )
             benchmark_task = benchmark_task_repository.save(db=db, model=benchmark_task)
             return benchmark_task
 
@@ -218,6 +232,7 @@ class BenchmarkerV2(NetsPressoBase):
         wait_until_done: bool = True,
         sleep_interval: int = 30,
         input_model_id: Optional[str] = None,
+        benchmark_task_id: Optional[str] = None,
     ) -> BenchmarkerMetadata:
         """Benchmark the specified model on the specified device.
 
@@ -278,6 +293,7 @@ class BenchmarkerV2(NetsPressoBase):
             data_type=data_type,
             input_model_id=input_model_id,
             model_id=model.model_id,
+            benchmark_task_id=benchmark_task_id,
         )
 
         try:

--- a/netspresso/converter/v2/converter.py
+++ b/netspresso/converter/v2/converter.py
@@ -155,6 +155,7 @@ class ConverterV2(NetsPressoBase):
         data_type: Union[str, DataType],
         input_model_id: Optional[str] = None,
         model_id: Optional[str] = None,
+        conversion_task_id: Optional[str] = None,
     ) -> ConversionTask:
         """Create a new conversion task.
 
@@ -170,16 +171,29 @@ class ConverterV2(NetsPressoBase):
             Created conversion task object
         """
         with get_db_session() as db:
-            conversion_task = ConversionTask(
-                framework=framework,
-                device_name=device_name,
-                software_version=software_version,
-                precision=data_type,
-                status=Status.NOT_STARTED,
-                input_model_id=input_model_id,
-                model_id=model_id,
-                user_id=self.user_info.user_id,
-            )
+            if conversion_task_id:
+                conversion_task = ConversionTask(
+                    task_id=conversion_task_id,
+                    framework=framework,
+                    device_name=device_name,
+                    software_version=software_version,
+                    precision=data_type,
+                    status=Status.NOT_STARTED,
+                    input_model_id=input_model_id,
+                    model_id=model_id,
+                    user_id=self.user_info.user_id,
+                )
+            else:
+                conversion_task = ConversionTask(
+                    framework=framework,
+                    device_name=device_name,
+                    software_version=software_version,
+                    precision=data_type,
+                    status=Status.NOT_STARTED,
+                    input_model_id=input_model_id,
+                    model_id=model_id,
+                    user_id=self.user_info.user_id,
+                )
             conversion_task = conversion_task_repository.save(db=db, model=conversion_task)
             return conversion_task
 
@@ -208,6 +222,7 @@ class ConverterV2(NetsPressoBase):
         wait_until_done: bool = True,
         sleep_interval: int = 30,
         output_dir: Optional[str] = None,
+        conversion_task_id: Optional[str] = None,
     ) -> str:
         """Convert a model using its model ID.
 
@@ -274,6 +289,7 @@ class ConverterV2(NetsPressoBase):
                 dataset_path=dataset_path,
                 wait_until_done=wait_until_done,
                 sleep_interval=sleep_interval,
+                conversion_task_id=conversion_task_id,
             )
         except Exception as e:
             logger.error(f"Error in convert_model_from_id: {e}")
@@ -393,6 +409,7 @@ class ConverterV2(NetsPressoBase):
         dataset_path: Optional[str] = None,
         wait_until_done: bool = True,
         sleep_interval: int = 30,
+        conversion_task_id: Optional[str] = None,
     ) -> str:
         """Perform the actual model conversion (common logic)
 
@@ -452,6 +469,7 @@ class ConverterV2(NetsPressoBase):
             data_type=target_data_type,
             input_model_id=input_model.model_id,
             model_id=model.model_id,
+            conversion_task_id=conversion_task_id,
         )
 
         try:
@@ -570,6 +588,7 @@ class ConverterV2(NetsPressoBase):
         sleep_interval: int = 30,
         input_model_id: Optional[str] = None,
         project_id: Optional[str] = None,
+        conversion_task_id: Optional[str] = None,
     ) -> str:
         """Convert a model to the specified framework.
 
@@ -610,6 +629,7 @@ class ConverterV2(NetsPressoBase):
                 wait_until_done=wait_until_done,
                 sleep_interval=sleep_interval,
                 output_dir=output_dir,
+                conversion_task_id=conversion_task_id,
             )
         elif input_model_path:
             return self.convert_model_from_path(


### PR DESCRIPTION
## Description

Please include a summary in English, of the changes in this pull request. If it closes an issue, please mention it here.

Closes: #(issue)

You should link at least one existing issue for PR. Before your create a PR, please check to see if there is an issue for this change.  
PRs from forked repository not accepted.

## Change(s)

- Add benchmark task ID generation before run celery worker.
- Add conversion task ID generation before run celery worker.
