### PR TITLE
Add compression status field and return compression task IDs

### DIFF
--- a/app/api/v1/schemas/model.py
+++ b/app/api/v1/schemas/model.py
@@ -9,10 +9,10 @@ from netspresso.enums import Status
 
 
 class ExperimentStatus(BaseModel):
+    compress: Status = Field(default=Status.NOT_STARTED, description="The status of the compression experiment.")
     convert: Status = Field(default=Status.NOT_STARTED, description="The status of the conversion experiment.")
     benchmark: Status = Field(default=Status.NOT_STARTED, description="The status of the benchmark experiment.")
     evaluate: Status = Field(default=Status.NOT_STARTED, description="The status of the evaluation experiment.")
-
 
 class ModelPayload(BaseModel):
     model_config = ConfigDict(from_attributes=True)

--- a/app/services/model.py
+++ b/app/services/model.py
@@ -108,6 +108,26 @@ class ModelService:
 
         return latest_status, task_ids
 
+    def _get_compression_info(self, db: Session, model_id: str) -> tuple[Optional[str], List[str]]:
+        """Get compression task information for a model
+
+        Args:
+            db: Database session
+            model_id: Model ID to get compression tasks for
+
+        Returns:
+            tuple: (latest status, task IDs)
+        """
+        compression_tasks = compression_task_repository.get_all_by_input_model_id(db=db, input_model_id=model_id)
+        if not compression_tasks:
+            return None, []
+
+        task_ids = [task.task_id for task in compression_tasks]
+        compression_task = compression_task_repository.get_latest_compression_task(db=db, input_model_id=model_id)
+        latest_status = compression_task.status
+
+        return latest_status, task_ids
+
     def _attach_child_task_info(self, db: Session, model: ModelPayload) -> ModelPayload:
         """Attach child tasks (conversion, benchmark, evaluation) information to model
 
@@ -123,6 +143,12 @@ class ModelService:
         if eval_status:
             model.latest_experiments.evaluate = eval_status
             model.evaluation_task_ids.extend(eval_task_ids)
+
+        # Get compression tasks
+        comp_status, comp_task_ids = self._get_compression_info(db, model.model_id)
+        if comp_status:
+            model.latest_experiments.compress = comp_status
+            model.compress_task_ids.extend(comp_task_ids)
 
         # Get conversion tasks and their benchmark tasks
         conv_status, conv_task_ids, conv_model_ids = self._get_conversion_info(db, model.model_id)

--- a/netspresso/utils/db/repositories/compression.py
+++ b/netspresso/utils/db/repositories/compression.py
@@ -4,7 +4,7 @@ from sqlalchemy.orm import Session
 
 from netspresso.exceptions.compression import CompressionTaskIsDeletedException, CompressionTaskNotFoundException
 from netspresso.utils.db.models.compression import CompressionModelResult, CompressionTask
-from netspresso.utils.db.repositories.base import BaseRepository
+from netspresso.utils.db.repositories.base import BaseRepository, Order, TimeSort
 
 
 class CompressionTaskRepository(BaseRepository[CompressionTask]):
@@ -32,11 +32,32 @@ class CompressionTaskRepository(BaseRepository[CompressionTask]):
 
         return self.__is_available(task=task)
 
-    def get_all_by_input_model_id(self, db: Session, input_model_id: str) -> List[CompressionTask]:
+    def get_all_by_input_model_id(
+        self, db: Session, input_model_id: str, order: Order = Order.DESC, time_sort: TimeSort = TimeSort.CREATED_AT
+    ) -> List[CompressionTask]:
         conditions = [self.model.input_model_id == input_model_id]
-        tasks = self.find_all(db=db, conditions=conditions)
+        tasks = self.find_all(db=db, conditions=conditions, order=order, time_sort=time_sort)
 
         return tasks
+
+    def get_latest_compression_task(
+        self, db: Session, input_model_id: str, order: Order = Order.DESC, time_sort: TimeSort = TimeSort.UPDATED_AT
+    ) -> Optional[CompressionTask]:
+        """Get the latest compression task for a model.
+
+        Args:
+            db: Database session
+            input_model_id: Input model ID
+            order: Order of results (default: DESC)
+            time_sort: Time field to sort by (default: UPDATED_AT)
+
+        Returns:
+            Optional[CompressionTask]: Latest compression task if exists
+        """
+        conditions = [self.model.input_model_id == input_model_id]
+        task = self.find_first(db=db, conditions=conditions, order=order, time_sort=time_sort)
+
+        return self.__is_available(task=task)
 
 
 class CompressionModelResultRepository(BaseRepository[CompressionModelResult]):


### PR DESCRIPTION
## Description

Please include a summary in English, of the changes in this pull request. If it closes an issue, please mention it here.

Closes: #(issue)

You should link at least one existing issue for PR. Before your create a PR, please check to see if there is an issue for this change.  
PRs from forked repository not accepted.

## Change(s)

- Add compress status field to ExperimentStatus schema.
- Add sorting options to get_all_by_input_model_id and implement get_latest_compression_task method.
- Add method to retrieve compression task information and integrate it into model data.
