### PR TITLE
Fix CompressionsResponse to inherit from ResponsePaginationItems

### DIFF
--- a/app/api/v1/schemas/task/compression/compression_task.py
+++ b/app/api/v1/schemas/task/compression/compression_task.py
@@ -3,7 +3,7 @@ from typing import Dict, List, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-from app.api.v1.schemas.base import ResponseItem
+from app.api.v1.schemas.base import ResponseItem, ResponsePaginationItems
 from netspresso.enums.compression import CompressionMethod, GroupPolicy, LayerNorm, Policy, RecommendationMethod, StepOp
 from netspresso.exceptions.compressor import (
     NotValidChannelAxisRangeException,
@@ -96,7 +96,7 @@ class CompressionResponse(ResponseItem):
     data: CompressionPayload
 
 
-class CompressionsResponse(ResponseItem):
+class CompressionsResponse(ResponsePaginationItems):
     data: List[CompressionPayload]
     result_count: int
     total_count: int


### PR DESCRIPTION
## Description

Please include a summary in English, of the changes in this pull request. If it closes an issue, please mention it here.

Closes: #(issue)

You should link at least one existing issue for PR. Before your create a PR, please check to see if there is an issue for this change.  
PRs from forked repository not accepted.

## Change(s)

- Fix CompressionsResponse to inherit from ResponsePaginationItems.