### PR TITLE
Fix save_benchmark_result call to use task_id instead of task object

### DIFF
--- a/netspresso/benchmarker/v2/benchmarker.py
+++ b/netspresso/benchmarker/v2/benchmarker.py
@@ -361,7 +361,7 @@ class BenchmarkerV2(NetsPressoBase):
 
                 # Save benchmark results
                 _benchmark_result = benchmark_response.data.benchmark_result
-                benchmark_task = self.save_benchmark_result(benchmark_task, _benchmark_result)
+                benchmark_task = self.save_benchmark_result(benchmark_task.task_id, _benchmark_result)
 
                 logger.info("Benchmark task was completed successfully.")
             elif benchmark_response.data.status in [

--- a/netspresso/benchmarker/v2/benchmarker.py
+++ b/netspresso/benchmarker/v2/benchmarker.py
@@ -178,6 +178,8 @@ class BenchmarkerV2(NetsPressoBase):
             db.add(benchmark_task)
             db.commit()
 
+            return benchmark_task
+
     def create_benchmark_result(self, benchmark_task: BenchmarkTask, file_size: float) -> BenchmarkTask:
         benchmark_result = BenchmarkResult(file_size=file_size, task_id=benchmark_task.task_id)
         with get_db_session() as db:

--- a/netspresso/benchmarker/v2/benchmarker.py
+++ b/netspresso/benchmarker/v2/benchmarker.py
@@ -363,6 +363,7 @@ class BenchmarkerV2(NetsPressoBase):
 
                 # Save benchmark results
                 _benchmark_result = benchmark_response.data.benchmark_result
+                benchmark_task = self._save_benchmark_task(benchmark_task)
                 benchmark_task = self.save_benchmark_result(benchmark_task.task_id, _benchmark_result)
 
                 logger.info("Benchmark task was completed successfully.")


### PR DESCRIPTION
## Description

Please include a summary in English, of the changes in this pull request. If it closes an issue, please mention it here.

Closes: #(issue)

You should link at least one existing issue for PR. Before your create a PR, please check to see if there is an issue for this change.  
PRs from forked repository not accepted.

## Change(s)

- Fix save_benchmark_result call to use task_id instead of task object.
- Save benchmark task after saving benchmark results.
