### PR TITLE
Update ratio precision in CompressionTask model from 2,1 to 5,4

### DIFF
--- a/netspresso/utils/db/models/compression.py
+++ b/netspresso/utils/db/models/compression.py
@@ -34,7 +34,7 @@ class CompressionTask(BaseModel):
 
     # Compression settings
     method = Column(String(30), nullable=False)
-    ratio = Column(Numeric(precision=2, scale=1), nullable=False)
+    ratio = Column(Numeric(precision=5, scale=4), nullable=False)
     options = Column(JSON, nullable=True)
     layers = Column(JSON, nullable=True)
 


### PR DESCRIPTION
## Description

Please include a summary in English, of the changes in this pull request. If it closes an issue, please mention it here.

Closes: #(issue)

You should link at least one existing issue for PR. Before your create a PR, please check to see if there is an issue for this change.  
PRs from forked repository not accepted.

## Change(s)

- Update ratio precision in CompressionTask model from 2,1 to 5,4.
