### PR TITLE
Upgrade qai-hub from 0.29.0 → 0.40.0 and Add ONNX ZIP extraction support

### DIFF
--- a/netspresso/np_qai/base.py
+++ b/netspresso/np_qai/base.py
@@ -1,8 +1,25 @@
+import os
+import shutil
+import zipfile
 from pathlib import Path
 from typing import List, Optional, Union
 
+import onnx
 import qai_hub as hub
-from qai_hub.client import Dataset, Device, Job, JobStatus, JobSummary, JobType, Model, SourceModel, SourceModelType
+from loguru import logger
+from qai_hub.client import (
+    CompileJob,
+    Dataset,
+    Device,
+    Job,
+    JobStatus,
+    JobSummary,
+    JobType,
+    Model,
+    QuantizeJob,
+    SourceModel,
+    SourceModelType,
+)
 
 from netspresso.np_qai.options import Extension, Framework, Runtime
 
@@ -268,3 +285,113 @@ class NPQAIBase:
             Framework.QNN: "QNN",
         }
         return RUNTIME_DISPLAY_MAP.get(framework, "Unknown runtime")
+
+    def download_model(self, job: Union[CompileJob, QuantizeJob], filename: str) -> str:
+        """
+        Download a model from the QAI Hub and handle ONNX zip conversion.
+
+        Args:
+            job: The job to download the model from (CompileJob or QuantizeJob).
+            filename: The filename to save the model to.
+
+        Returns:
+            str: The actual path of the downloaded and processed model.
+
+        Note:
+            Since QAI Hub July 2025 update, ONNX models are always downloaded as .zip files
+            with external weights. Other formats (.tflite, .so, .bin) are downloaded directly.
+            Reference: https://app.aihub.qualcomm.com/docs/hub/release_notes.html#released-july-14-2025
+
+            This function automatically extracts and converts ONNX zip files to single .onnx files
+            with embedded weights. Non-ONNX models are returned as-is.
+        """
+        # Download the model
+        downloaded_filename = job.download_target_model(filename=filename)
+
+        # Use the original filename as fallback if download doesn't return a path
+        if downloaded_filename is None:
+            downloaded_filename = filename
+
+        # Verify file exists
+        if not os.path.exists(downloaded_filename):
+            raise FileNotFoundError(f"Downloaded file not found: {downloaded_filename}")
+
+        # Only ONNX models are downloaded as .zip (since QAI Hub July 2025 update)
+        # Other formats (.tflite, .so, .bin) are downloaded directly
+        is_onnx_zip = downloaded_filename.endswith('.onnx.zip') or (
+            zipfile.is_zipfile(downloaded_filename) and '.onnx' in filename.lower()
+        )
+
+        if is_onnx_zip:
+            return self._extract_and_convert_onnx_zip(downloaded_filename)
+
+        # Non-ONNX models: return as-is
+        return downloaded_filename
+
+    def _extract_and_convert_onnx_zip(self, zip_path: str) -> str:
+        """
+        Extract and convert ONNX model from zip file to single .onnx file with embedded weights.
+
+        Args:
+            zip_path: Path to the .onnx.zip file.
+
+        Returns:
+            str: Path to the converted .onnx file.
+
+        Note:
+            Since QAI Hub July 2025 update, ONNX models are always produced with external
+            weights in .zip format. This method extracts the zip and saves as a single .onnx file.
+            Reference: https://app.aihub.qualcomm.com/docs/hub/release_notes.html#released-july-14-2025
+        """
+        logger.info(f"Extracting ONNX model from zip: {zip_path}")
+
+        extract_dir = None
+        try:
+            # Create temporary extraction directory
+            extract_dir = f"{zip_path}_extracted"
+            os.makedirs(extract_dir, exist_ok=True)
+
+            # Extract the zip file
+            with zipfile.ZipFile(zip_path, 'r') as zip_ref:
+                zip_ref.extractall(extract_dir)
+
+            # Find ONNX file (recursively search subdirectories)
+            onnx_files = []
+            for root, _, files in os.walk(extract_dir):
+                for file in files:
+                    if file.endswith('.onnx'):
+                        onnx_files.append(os.path.join(root, file))
+
+            if not onnx_files:
+                raise FileNotFoundError(f"No ONNX file found in zip: {zip_path}")
+
+            if len(onnx_files) > 1:
+                logger.warning(f"Multiple ONNX files found in zip, using first: {onnx_files[0]}")
+
+            # Load ONNX model
+            extracted_onnx_path = onnx_files[0]
+            onnx_model = onnx.load(extracted_onnx_path)
+
+            # Determine final path: remove .zip extension
+            if zip_path.endswith('.onnx.zip'):
+                final_path = zip_path[:-4]  # Remove .zip, keep .onnx
+            elif zip_path.endswith('.zip'):
+                final_path = zip_path[:-4] + '.onnx'
+            else:
+                final_path = f"{zip_path}.onnx"
+
+            # Save as single ONNX file with embedded weights
+            onnx.save(onnx_model, final_path)
+            logger.info(f"ONNX model saved to: {final_path}")
+
+            return final_path
+
+        finally:
+            # Always cleanup temporary files
+            try:
+                if os.path.exists(zip_path):
+                    os.remove(zip_path)
+                if extract_dir and os.path.exists(extract_dir):
+                    shutil.rmtree(extract_dir)
+            except Exception as e:
+                logger.warning(f"Failed to cleanup temporary files: {e}")

--- a/netspresso/np_qai/base.py
+++ b/netspresso/np_qai/base.py
@@ -208,8 +208,9 @@ class NPQAIBase:
     def get_target_extension(self, runtime=Runtime.TFLITE):
         runtime_extensions = {
             Runtime.TFLITE: ".tflite",
-            Runtime.QNN_LIB_AARCH64_ANDROID: ".so",
+            Runtime.QNN_LIB_AARCH64_ANDROID: ".so",  # Deprecated in qai-hub 0.40.0
             Runtime.QNN_CONTEXT_BINARY: ".bin",
+            Runtime.QNN_DLC: ".dlc",  # Added in qai-hub 0.40.0
             Runtime.ONNX: ".onnx",
             Runtime.PRECOMPILED_QNN_ONNX: ".zip",
         }
@@ -219,8 +220,9 @@ class NPQAIBase:
     def get_display_runtime(self, runtime: Runtime) -> str:
         RUNTIME_DISPLAY_MAP = {
             Runtime.TFLITE: "TensorFlow Lite",
-            Runtime.QNN_LIB_AARCH64_ANDROID: "Qualcomm® AI Engine Direct model library targeting AArch64 Android",
+            Runtime.QNN_LIB_AARCH64_ANDROID: "Qualcomm® AI Engine Direct model library targeting AArch64 Android (Deprecated - use QNN_DLC)",
             Runtime.QNN_CONTEXT_BINARY: "Qualcomm® AI Engine Direct context binary targeting the hardware specified in the compile job.",
+            Runtime.QNN_DLC: "Qualcomm® AI Engine Direct DLC (Deep Learning Container) - Recommended for QNN deployment",
             Runtime.ONNX: "ONNX",
             Runtime.PRECOMPILED_QNN_ONNX: "ONNX Runtime model with a pre-compiled QNN context binary.",
         }
@@ -231,6 +233,7 @@ class NPQAIBase:
             Runtime.TFLITE: Framework.TFLITE,
             Runtime.QNN_LIB_AARCH64_ANDROID: Framework.QNN,
             Runtime.QNN_CONTEXT_BINARY: Framework.QNN,
+            Runtime.QNN_DLC: Framework.QNN,  # Added in qai-hub 0.40.0
             Runtime.ONNX: Framework.ONNX,
             Runtime.PRECOMPILED_QNN_ONNX: Framework.QNN,
         }

--- a/netspresso/np_qai/converter.py
+++ b/netspresso/np_qai/converter.py
@@ -1,6 +1,10 @@
+import os
+import shutil
+import zipfile
 from pathlib import Path
 from typing import List, Optional, Union
 
+import onnx
 import qai_hub as hub
 from loguru import logger
 from qai_hub import JobStatus
@@ -58,7 +62,8 @@ class NPQAIConverter(NPQAIBase):
 
         if status.success:
             logger.info(f"{status.symbol} {status.state.name}")
-            self.download_model(job=job, filename=metadata.converted_model_path)
+            actual_model_path = self.download_model(job=job, filename=metadata.converted_model_path)
+            metadata.converted_model_path = actual_model_path
             target_model = job.get_target_model()
             metadata.convert_task_info.output_model_uuid = target_model.model_id
             metadata.convert_task_info.data_type = job.target_shapes["image"][1]
@@ -163,15 +168,85 @@ class NPQAIConverter(NPQAIBase):
 
         return metadata
 
-    def download_model(self, job: CompileJob, filename: str):
+    def download_model(self, job: CompileJob, filename: str) -> str:
         """
-        Download a model from the QAI Hub.
+        Download a model from the QAI Hub and handle .onnx.zip conversion.
 
         Args:
             job: The job to download the model from.
             filename: The filename to save the model to.
 
+        Returns:
+            str: The actual path of the downloaded and processed model.
+
         Note:
             For details, see [download_target_model in QAI Hub API](https://app.aihub.qualcomm.com/docs/hub/generated/qai_hub.CompileJob.html#qai_hub.CompileJob.download_target_model).
+            Since QAI Hub update, ONNX models are downloaded as .onnx.zip files.
+            This function automatically extracts and converts them to .onnx format.
         """
-        job.download_target_model(filename=filename)
+        # Download the model (QAI Hub may save it as .zip file for ONNX models)
+        downloaded_filename = job.download_target_model(filename=filename)
+
+        # Use the original filename as fallback if download doesn't return a path
+        if downloaded_filename is None:
+            downloaded_filename = filename
+
+        # Check if the downloaded file exists and is a zip file
+        if os.path.exists(downloaded_filename) and zipfile.is_zipfile(downloaded_filename):
+            logger.info(f"Downloaded file is a zip archive: {downloaded_filename}")
+            logger.info("Extracting model from zip file...")
+
+            # Extract the zip file
+            extract_dir = f"{downloaded_filename}_extracted"
+            os.makedirs(extract_dir, exist_ok=True)
+
+            with zipfile.ZipFile(downloaded_filename, 'r') as zip_ref:
+                zip_ref.extractall(extract_dir)
+
+            # Find the model file in the extracted directory (recursively search subdirectories)
+            model_files = []
+            for root, _, files in os.walk(extract_dir):
+                for file in files:
+                    if file.endswith(('.onnx', '.tflite', '.so', '.bin')):
+                        model_files.append(os.path.join(root, file))
+                        break
+                if model_files:
+                    break
+
+            if not model_files:
+                raise FileNotFoundError(f"No model file found in extracted zip: {downloaded_filename}")
+
+            # Load and save the model to the desired location
+            extracted_model_path = model_files[0]
+
+            # Determine the final path based on the model type
+            if extracted_model_path.endswith('.onnx'):
+                # For ONNX models, reload and save to ensure proper format
+                onnx_model = onnx.load(extracted_model_path)
+
+                # Save to the original filename with .onnx extension
+                # Remove .zip extension first
+                final_path = downloaded_filename.replace('.zip', '')
+                # Remove duplicate .onnx if present (e.g., .onnx.onnx -> .onnx)
+                if final_path.endswith('.onnx.onnx'):
+                    final_path = final_path[:-5]  # Remove one .onnx to leave just one
+                # Ensure it ends with .onnx
+                elif not final_path.endswith('.onnx'):
+                    final_path = f"{final_path}.onnx"
+
+                onnx.save(onnx_model, final_path)
+            else:
+                # For non-ONNX models, just copy the file
+                final_path = downloaded_filename.replace('.zip', '')
+                shutil.copy2(extracted_model_path, final_path)
+
+            logger.info(f"Model saved to: {final_path}")
+
+            # Clean up temporary files
+            os.remove(downloaded_filename)
+            shutil.rmtree(extract_dir)
+
+            return final_path
+
+        # If not a zip file, return the downloaded filename as is
+        return downloaded_filename

--- a/netspresso/np_qai/converter.py
+++ b/netspresso/np_qai/converter.py
@@ -1,10 +1,6 @@
-import os
-import shutil
-import zipfile
 from pathlib import Path
 from typing import List, Optional, Union
 
-import onnx
 import qai_hub as hub
 from loguru import logger
 from qai_hub import JobStatus
@@ -167,86 +163,3 @@ class NPQAIConverter(NPQAIBase):
             MetadataHandler.save_metadata(data=metadata, folder_path=output_dir)
 
         return metadata
-
-    def download_model(self, job: CompileJob, filename: str) -> str:
-        """
-        Download a model from the QAI Hub and handle .onnx.zip conversion.
-
-        Args:
-            job: The job to download the model from.
-            filename: The filename to save the model to.
-
-        Returns:
-            str: The actual path of the downloaded and processed model.
-
-        Note:
-            For details, see [download_target_model in QAI Hub API](https://app.aihub.qualcomm.com/docs/hub/generated/qai_hub.CompileJob.html#qai_hub.CompileJob.download_target_model).
-            Since QAI Hub update, ONNX models are downloaded as .onnx.zip files.
-            This function automatically extracts and converts them to .onnx format.
-        """
-        # Download the model (QAI Hub may save it as .zip file for ONNX models)
-        downloaded_filename = job.download_target_model(filename=filename)
-
-        # Use the original filename as fallback if download doesn't return a path
-        if downloaded_filename is None:
-            downloaded_filename = filename
-
-        # Check if the downloaded file exists and is a zip file
-        if os.path.exists(downloaded_filename) and zipfile.is_zipfile(downloaded_filename):
-            logger.info(f"Downloaded file is a zip archive: {downloaded_filename}")
-            logger.info("Extracting model from zip file...")
-
-            # Extract the zip file
-            extract_dir = f"{downloaded_filename}_extracted"
-            os.makedirs(extract_dir, exist_ok=True)
-
-            with zipfile.ZipFile(downloaded_filename, 'r') as zip_ref:
-                zip_ref.extractall(extract_dir)
-
-            # Find the model file in the extracted directory (recursively search subdirectories)
-            model_files = []
-            for root, _, files in os.walk(extract_dir):
-                for file in files:
-                    if file.endswith(('.onnx', '.tflite', '.so', '.bin')):
-                        model_files.append(os.path.join(root, file))
-                        break
-                if model_files:
-                    break
-
-            if not model_files:
-                raise FileNotFoundError(f"No model file found in extracted zip: {downloaded_filename}")
-
-            # Load and save the model to the desired location
-            extracted_model_path = model_files[0]
-
-            # Determine the final path based on the model type
-            if extracted_model_path.endswith('.onnx'):
-                # For ONNX models, reload and save to ensure proper format
-                onnx_model = onnx.load(extracted_model_path)
-
-                # Save to the original filename with .onnx extension
-                # Remove .zip extension first
-                final_path = downloaded_filename.replace('.zip', '')
-                # Remove duplicate .onnx if present (e.g., .onnx.onnx -> .onnx)
-                if final_path.endswith('.onnx.onnx'):
-                    final_path = final_path[:-5]  # Remove one .onnx to leave just one
-                # Ensure it ends with .onnx
-                elif not final_path.endswith('.onnx'):
-                    final_path = f"{final_path}.onnx"
-
-                onnx.save(onnx_model, final_path)
-            else:
-                # For non-ONNX models, just copy the file
-                final_path = downloaded_filename.replace('.zip', '')
-                shutil.copy2(extracted_model_path, final_path)
-
-            logger.info(f"Model saved to: {final_path}")
-
-            # Clean up temporary files
-            os.remove(downloaded_filename)
-            shutil.rmtree(extract_dir)
-
-            return final_path
-
-        # If not a zip file, return the downloaded filename as is
-        return downloaded_filename

--- a/netspresso/np_qai/options/compile.py
+++ b/netspresso/np_qai/options/compile.py
@@ -26,8 +26,9 @@ class Extension(StrEnum):
 
 class Runtime(StrEnum):
     TFLITE = "tflite"
-    QNN_LIB_AARCH64_ANDROID = "qnn_lib_aarch64_android"
+    QNN_LIB_AARCH64_ANDROID = "qnn_lib_aarch64_android"  # Deprecated in qai-hub 0.40.0
     QNN_CONTEXT_BINARY = "qnn_context_binary"
+    QNN_DLC = "qnn_dlc"  # Added in qai-hub 0.40.0 - Recommended for QNN deployment
     ONNX = "onnx"
     PRECOMPILED_QNN_ONNX = "precompiled_qnn_onnx"
 

--- a/netspresso/np_qai/quantizer.py
+++ b/netspresso/np_qai/quantizer.py
@@ -1,10 +1,6 @@
-import os
-import shutil
-import zipfile
 from pathlib import Path
 from typing import List, Optional, Union
 
-import onnx
 import qai_hub as hub
 from loguru import logger
 from qai_hub import JobStatus, QuantizeDtype
@@ -137,86 +133,3 @@ class NPQAIQuantizer(NPQAIBase):
             MetadataHandler.save_metadata(data=metadata, folder_path=output_dir)
 
         return metadata
-
-    def download_model(self, job: QuantizeJob, filename: str) -> str:
-        """
-        Download a model from the QAI Hub and handle .onnx.zip conversion.
-
-        Args:
-            job: The job to download the model from.
-            filename: The filename to save the model to.
-
-        Returns:
-            str: The actual path of the downloaded and processed model.
-
-        Note:
-            For details, see [download_target_model in QAI Hub API](https://app.aihub.qualcomm.com/docs/hub/generated/qai_hub.QuantizeJob.html#qai_hub.QuantizeJob.download_target_model).
-            Since QAI Hub update, ONNX models are downloaded as .onnx.zip files.
-            This function automatically extracts and converts them to .onnx format.
-        """
-        # Download the model (QAI Hub may save it as .zip file for ONNX models)
-        downloaded_filename = job.download_target_model(filename=filename)
-
-        # Use the original filename as fallback if download doesn't return a path
-        if downloaded_filename is None:
-            downloaded_filename = filename
-
-        # Check if the downloaded file exists and is a zip file
-        if os.path.exists(downloaded_filename) and zipfile.is_zipfile(downloaded_filename):
-            logger.info(f"Downloaded file is a zip archive: {downloaded_filename}")
-            logger.info("Extracting model from zip file...")
-
-            # Extract the zip file
-            extract_dir = f"{downloaded_filename}_extracted"
-            os.makedirs(extract_dir, exist_ok=True)
-
-            with zipfile.ZipFile(downloaded_filename, 'r') as zip_ref:
-                zip_ref.extractall(extract_dir)
-
-            # Find the model file in the extracted directory (recursively search subdirectories)
-            model_files = []
-            for root, _, files in os.walk(extract_dir):
-                for file in files:
-                    if file.endswith(('.onnx', '.tflite', '.so', '.bin')):
-                        model_files.append(os.path.join(root, file))
-                        break
-                if model_files:
-                    break
-
-            if not model_files:
-                raise FileNotFoundError(f"No model file found in extracted zip: {downloaded_filename}")
-
-            # Load and save the model to the desired location
-            extracted_model_path = model_files[0]
-
-            # Determine the final path based on the model type
-            if extracted_model_path.endswith('.onnx'):
-                # For ONNX models, reload and save to ensure proper format
-                onnx_model = onnx.load(extracted_model_path)
-
-                # Save to the original filename with .onnx extension
-                # Remove .zip extension first
-                final_path = downloaded_filename.replace('.zip', '')
-                # Remove duplicate .onnx if present (e.g., .onnx.onnx -> .onnx)
-                if final_path.endswith('.onnx.onnx'):
-                    final_path = final_path[:-5]  # Remove one .onnx to leave just one
-                # Ensure it ends with .onnx
-                elif not final_path.endswith('.onnx'):
-                    final_path = f"{final_path}.onnx"
-
-                onnx.save(onnx_model, final_path)
-            else:
-                # For non-ONNX models, just copy the file
-                final_path = downloaded_filename.replace('.zip', '')
-                shutil.copy2(extracted_model_path, final_path)
-
-            logger.info(f"Model saved to: {final_path}")
-
-            # Clean up temporary files
-            os.remove(downloaded_filename)
-            shutil.rmtree(extract_dir)
-
-            return final_path
-
-        # If not a zip file, return the downloaded filename as is
-        return downloaded_filename

--- a/netspresso/np_qai/quantizer.py
+++ b/netspresso/np_qai/quantizer.py
@@ -1,6 +1,10 @@
+import os
+import shutil
+import zipfile
 from pathlib import Path
 from typing import List, Optional, Union
 
+import onnx
 import qai_hub as hub
 from loguru import logger
 from qai_hub import JobStatus, QuantizeDtype
@@ -50,7 +54,8 @@ class NPQAIQuantizer(NPQAIBase):
 
         if status.success:
             logger.info(f"{status.symbol} {status.state.name}")
-            self.download_model(job=job, filename=metadata.quantized_model_path)
+            actual_model_path = self.download_model(job=job, filename=metadata.quantized_model_path)
+            metadata.quantized_model_path = actual_model_path
             target_model = job.get_target_model()
             metadata.quantize_info.output_model_uuid = target_model.model_id
             metadata.status = Status.COMPLETED
@@ -133,15 +138,85 @@ class NPQAIQuantizer(NPQAIBase):
 
         return metadata
 
-    def download_model(self, job: QuantizeJob, filename: str):
+    def download_model(self, job: QuantizeJob, filename: str) -> str:
         """
-        Download a model from the QAI hub.
+        Download a model from the QAI Hub and handle .onnx.zip conversion.
 
         Args:
             job: The job to download the model from.
             filename: The filename to save the model to.
 
+        Returns:
+            str: The actual path of the downloaded and processed model.
+
         Note:
             For details, see [download_target_model in QAI Hub API](https://app.aihub.qualcomm.com/docs/hub/generated/qai_hub.QuantizeJob.html#qai_hub.QuantizeJob.download_target_model).
+            Since QAI Hub update, ONNX models are downloaded as .onnx.zip files.
+            This function automatically extracts and converts them to .onnx format.
         """
-        job.download_target_model(filename=filename)
+        # Download the model (QAI Hub may save it as .zip file for ONNX models)
+        downloaded_filename = job.download_target_model(filename=filename)
+
+        # Use the original filename as fallback if download doesn't return a path
+        if downloaded_filename is None:
+            downloaded_filename = filename
+
+        # Check if the downloaded file exists and is a zip file
+        if os.path.exists(downloaded_filename) and zipfile.is_zipfile(downloaded_filename):
+            logger.info(f"Downloaded file is a zip archive: {downloaded_filename}")
+            logger.info("Extracting model from zip file...")
+
+            # Extract the zip file
+            extract_dir = f"{downloaded_filename}_extracted"
+            os.makedirs(extract_dir, exist_ok=True)
+
+            with zipfile.ZipFile(downloaded_filename, 'r') as zip_ref:
+                zip_ref.extractall(extract_dir)
+
+            # Find the model file in the extracted directory (recursively search subdirectories)
+            model_files = []
+            for root, _, files in os.walk(extract_dir):
+                for file in files:
+                    if file.endswith(('.onnx', '.tflite', '.so', '.bin')):
+                        model_files.append(os.path.join(root, file))
+                        break
+                if model_files:
+                    break
+
+            if not model_files:
+                raise FileNotFoundError(f"No model file found in extracted zip: {downloaded_filename}")
+
+            # Load and save the model to the desired location
+            extracted_model_path = model_files[0]
+
+            # Determine the final path based on the model type
+            if extracted_model_path.endswith('.onnx'):
+                # For ONNX models, reload and save to ensure proper format
+                onnx_model = onnx.load(extracted_model_path)
+
+                # Save to the original filename with .onnx extension
+                # Remove .zip extension first
+                final_path = downloaded_filename.replace('.zip', '')
+                # Remove duplicate .onnx if present (e.g., .onnx.onnx -> .onnx)
+                if final_path.endswith('.onnx.onnx'):
+                    final_path = final_path[:-5]  # Remove one .onnx to leave just one
+                # Ensure it ends with .onnx
+                elif not final_path.endswith('.onnx'):
+                    final_path = f"{final_path}.onnx"
+
+                onnx.save(onnx_model, final_path)
+            else:
+                # For non-ONNX models, just copy the file
+                final_path = downloaded_filename.replace('.zip', '')
+                shutil.copy2(extracted_model_path, final_path)
+
+            logger.info(f"Model saved to: {final_path}")
+
+            # Clean up temporary files
+            os.remove(downloaded_filename)
+            shutil.rmtree(extract_dir)
+
+            return final_path
+
+        # If not a zip file, return the downloaded filename as is
+        return downloaded_filename

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ requests-toolbelt>=1.0.0
 python-dotenv>=1.0.0
 netspresso-inference-package==0.1.4
 scipy
-qai-hub==0.29.0
+qai-hub==0.40.0


### PR DESCRIPTION
## Description

This PR upgrades qai-hub from v0.29.0 → v0.40.0 and updates the QAI Hub integration inside PyNetsPresso to support:
- New runtime formats (especially QNN_DLC)
- Updated ONNX packaging (now delivered as .onnx.zip)
- Automatic extraction, normalization, and cleanup for zip-based model artifacts
- Enhancements to quantization flow (NPQAIQuantizer)

Closes: #(issue)

You should link at least one existing issue for PR. Before your create a PR, please check to see if there is an issue for this change.  
PRs from forked repository not accepted.

## Change(s)

- (Please write a description for this change.)
