### PR TITLE
Add automatic optimization for NXP i.MX93 target device

### DIFF
--- a/netspresso/clients/compressor/v2/schemas/compression/base.py
+++ b/netspresso/clients/compressor/v2/schemas/compression/base.py
@@ -1,7 +1,10 @@
 from dataclasses import dataclass, field
-from typing import List
+from typing import List, Optional
+
+from loguru import logger
 
 from netspresso.enums.compression import GroupPolicy, LayerNorm, Policy, StepOp
+from netspresso.enums.device import DeviceName
 from netspresso.exceptions.compressor import NotValidChannelAxisRangeException
 
 
@@ -23,6 +26,30 @@ class Options(OptionsBase):
     step_size: int = 2
     step_op: StepOp = StepOp.ROUND
     reverse: bool = False
+    target_device_name: Optional[str] = None
+
+    def __post_init__(self):
+        super().__post_init__()
+
+        # Apply hardware-specific step size configuration
+        if self.target_device_name is not None:
+            self._apply_hardware_config()
+
+    def _apply_hardware_config(self):
+        """Apply hardware-specific step size and operation configuration for target device."""
+        if self.target_device_name is None:
+            return
+
+        # Normalize device name (case-insensitive matching)
+        device_name_lower = self.target_device_name.lower()
+
+        # Check if target device is NXP iMX93
+        if device_name_lower in [DeviceName.NXP_iMX93.lower(), DeviceName.NXP_iMX93.value.lower()]:
+            self.step_size = 8
+            self.step_op = StepOp.ROUND_DOWN
+            logger.info(f"🎯 Hardware-aware compression enabled for {DeviceName.NXP_iMX93.value}")
+            logger.info(f"   → step_size: {self.step_size}, step_op: {self.step_op.value}")
+            logger.info("   → Reason: NPU requires 8-channel alignment for optimal performance")
 
 
 @dataclass


### PR DESCRIPTION
## Description

This PR introduces hardware-aware compression optimization for the NXP i.MX93 target device.

When users specify target_device_name="NXP_iMX93" (case-insensitive), the compression Options class now automatically applies the correct step size and step operation required by the NPU for optimal performance.

This reduces user configuration burden, prevents misconfiguration, and ensures the compression pipeline aligns with hardware constraints.

Closes: #(issue)

You should link at least one existing issue for PR. Before your create a PR, please check to see if there is an issue for this change.  
PRs from forked repository not accepted.

## Change(s)

- (Please write a description for this change.)
